### PR TITLE
Feature: There can be a case when a developer doesn't want to increme…

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,7 @@ export const addZeros = (counter: number, size: number) => {
  * @param serial 
  */
 export const extractCounter = (options: Options, serial: string): string => {
-  let { separator, initCounter, digits = 10, ignoreIncrementOnEdit = true } = options
+  let { separator, initCounter, digits = 10, ignoreIncrementOnEdit } = options
   let counter: string
 
   if (serial !== null) {
@@ -79,7 +79,7 @@ export const extractCounter = (options: Options, serial: string): string => {
  * @param options 
  */
 export const plugin = (schema: Schema, options: Options) => {
-  let { field, prefix, separator, initCounter, ignoreIncrementOnEdit } = options
+  let { field, prefix, separator, initCounter, ignoreIncrementOnEdit = true } = options
   let counter;
   schema.pre("save", async function (next) {
     let doc: any = this

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ export type Options = {
   separator: string,
   initCounter: "yearly" | "monthly" | "daily" | "hourly"
   digits: number,
-  updateExistingRecord: boolean
+  ignoreIncrementOnEdit: boolean
 }
 
 /**
@@ -41,7 +41,7 @@ export const addZeros = (counter: number, size: number) => {
  * @param serial 
  */
 export const extractCounter = (options: Options, serial: string): string => {
-  let { separator, initCounter, digits = 10, updateExistingRecord } = options
+  let { separator, initCounter, digits = 10, ignoreIncrementOnEdit } = options
   let counter: string
 
   if (serial !== null) {
@@ -79,7 +79,7 @@ export const extractCounter = (options: Options, serial: string): string => {
  * @param options 
  */
 export const plugin = (schema: Schema, options: Options) => {
-  let { field, prefix, separator, initCounter, updateExistingRecord } = options
+  let { field, prefix, separator, initCounter, ignoreIncrementOnEdit } = options
   let counter;
   schema.pre("save", async function (next) {
     let doc: any = this
@@ -101,7 +101,7 @@ export const plugin = (schema: Schema, options: Options) => {
     
     // if doc[field] has some value then
     // we are editing an existing record
-    if(updateExistingRecord && doc[field] && doc[field].length > 0) {
+    if(ignoreIncrementOnEdit && doc[field] && doc[field].length > 0) {
         next()
         return
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,7 +79,7 @@ export const extractCounter = (options: Options, serial: string): string => {
  * @param options 
  */
 export const plugin = (schema: Schema, options: Options) => {
-  let { field, prefix, separator, initCounter, ignoreIncrementOnEdit } = options
+  let { field, prefix, separator, initCounter, ignoreIncrementOnEdit = true } = options
   let counter;
   schema.pre("save", async function (next) {
     let doc: any = this

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,7 @@ export const addZeros = (counter: number, size: number) => {
  * @param serial 
  */
 export const extractCounter = (options: Options, serial: string): string => {
-  let { separator, initCounter, digits = 10, ignoreIncrementOnEdit } = options
+  let { separator, initCounter, digits = 10, ignoreIncrementOnEdit = true } = options
   let counter: string
 
   if (serial !== null) {
@@ -79,7 +79,7 @@ export const extractCounter = (options: Options, serial: string): string => {
  * @param options 
  */
 export const plugin = (schema: Schema, options: Options) => {
-  let { field, prefix, separator, initCounter, ignoreIncrementOnEdit = true } = options
+  let { field, prefix, separator, initCounter, ignoreIncrementOnEdit } = options
   let counter;
   schema.pre("save", async function (next) {
     let doc: any = this

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,8 @@ export type Options = {
   format: string,
   separator: string,
   initCounter: "yearly" | "monthly" | "daily" | "hourly"
-  digits: number
+  digits: number,
+  updateExistingRecord: boolean
 }
 
 /**
@@ -40,7 +41,7 @@ export const addZeros = (counter: number, size: number) => {
  * @param serial 
  */
 export const extractCounter = (options: Options, serial: string): string => {
-  let { separator, initCounter, digits = 10 } = options
+  let { separator, initCounter, digits = 10, updateExistingRecord } = options
   let counter: string
 
   if (serial !== null) {
@@ -78,7 +79,7 @@ export const extractCounter = (options: Options, serial: string): string => {
  * @param options 
  */
 export const plugin = (schema: Schema, options: Options) => {
-  let { field, prefix, separator, initCounter } = options
+  let { field, prefix, separator, initCounter, updateExistingRecord } = options
   let counter;
   schema.pre("save", async function (next) {
     let doc: any = this
@@ -97,6 +98,13 @@ export const plugin = (schema: Schema, options: Options) => {
     let serial = lastDoc ? lastDoc[field] : null
 
     counter = extractCounter(options, serial)
+    
+    // if doc[field] has some value then
+    // we are editing an existing record
+    if(updateExistingRecord && doc[field] && doc[field].length > 0) {
+        next()
+        return
+    }
 
     // retrive the last count
     let dating;

--- a/src/test/basic.test.ts
+++ b/src/test/basic.test.ts
@@ -7,7 +7,7 @@ let connection: any;
 const should = require('chai').should()
 
 
-let options = { field: 'serial', prefix: "Invoice", separator: "-", digits: 5, initCounter: "monthly", updateExistingRecord: false }
+let options = { field: 'serial', prefix: "Invoice", separator: "-", digits: 5, initCounter: "monthly", ignoreIncrementOnEdit: false }
 
 // create invoice model
 var invoiceSchema = new mongoose.Schema({
@@ -74,7 +74,7 @@ describe('Mongoose-serial', function () {
   it('should not increment Invoices on edit operation', function (done) {
 
     // set updateExisitingRecord to true
-    options.updateExistingRecord = true;
+    options.ignoreIncrementOnEdit = true;
 
     invoiceSchema.plugin(plugin, options);
     let Invoice = connection.model('Invoice2', invoiceSchema);

--- a/src/test/basic.test.ts
+++ b/src/test/basic.test.ts
@@ -1,4 +1,4 @@
-import { expect } from "chai";
+import { expect, assert } from "chai";
 
 const async = require('async')
 const mongoose = require('mongoose')
@@ -7,7 +7,14 @@ let connection: any;
 const should = require('chai').should()
 
 
-let options = { field: 'serial', prefix: "Invoice", separator: "-", digits: 5, initCounter: "monthly" }
+let options = { field: 'serial', prefix: "Invoice", separator: "-", digits: 5, initCounter: "monthly", updateExistingRecord: false }
+
+// create invoice model
+var invoiceSchema = new mongoose.Schema({
+    serial: String,
+    ht: Number,
+    ttc: Number,
+});
 
 before(function (done) {
   connection = mongoose.createConnection('mongodb://127.0.0.1/mongoose-serial-basic', { useNewUrlParser: true, useUnifiedTopology: true });
@@ -30,12 +37,6 @@ describe('Mongoose-serial', function () {
 
   it('should save the Invoices', function (done) {
 
-    // create invoice model
-    var invoiceSchema = new mongoose.Schema({
-      serial: String,
-      ht: Number,
-      ttc: Number,
-    });
     invoiceSchema.plugin(plugin, options);
     let Invoice = connection.model('Invoice', invoiceSchema);
     let invoice1 = new Invoice({ ht: 10000, ttc: 10010 });
@@ -70,4 +71,56 @@ describe('Mongoose-serial', function () {
 
   });
 
+  it('should not increment Invoices on edit operation', function (done) {
+
+    // set updateExisitingRecord to true
+    options.updateExistingRecord = true;
+
+    invoiceSchema.plugin(plugin, options);
+    let Invoice = connection.model('Invoice2', invoiceSchema);
+    let invoice1 = new Invoice({ ht: 10000, ttc: 10010 });
+    let invoice2 = new Invoice({ ht: 12000, ttc: 12010 });
+    let invoice3 = new Invoice({ ht: 13000, ttc: 12010 });
+    let invoice4 = new Invoice({ ht: 14000, ttc: 12010 });
+
+
+    // insert some invoices
+    async.series({
+      invoice1: function (cb: any) {
+        invoice1.save(cb);
+      },
+      invoice2: function (cb: any) {
+        invoice2.save(cb);
+      },
+      invoice3: function (cb: any) {
+        invoice3.save(cb);
+      },
+      invoice4: function (cb: any) {
+        invoice4.save(cb);
+      }
+    }, assertRecord);
+
+    // assert
+    function assertRecord(err: any, results: any) {
+      should.not.exist(err);
+      results.invoice1.should.have.property('ht', 10000);
+      results.invoice2.should.have.property('ht', 12000);
+      done();
+    }
+
+    // retrieve any existing invoice record
+    Invoice.findOne({ht:12000})
+    .then(function(data: any) {
+        const serial = data.serial;
+        data.ht = 15000;
+        data.save().then(function() {
+            Invoice.findOne({ht: 15000})
+            .then(function(verifyData: any) {
+                assert(serial === verifyData.serial, 'Edit operation should not increment invoice serial');
+            })
+            .catch(function(error: any){ throw error});
+        })
+    })
+    .catch(function(error: any){throw error});
+  });
 })

--- a/src/test/helerFunctions.test.ts
+++ b/src/test/helerFunctions.test.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 const { addZeros, extractCounter, InitCounter } = require('../')
 
-let options = { field: 'serial', prefix: "Invoice", format: "PREFIX", separator: "-", digits: 5, initCounter: "daily" }
+let options = { field: 'serial', prefix: "Invoice", format: "PREFIX", separator: "-", digits: 5, initCounter: "daily", updateExistingRecord: false}
 
 describe('Helper-functions', function () {
   it('should add lead zeros to integer number', () => {

--- a/src/test/helerFunctions.test.ts
+++ b/src/test/helerFunctions.test.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 const { addZeros, extractCounter, InitCounter } = require('../')
 
-let options = { field: 'serial', prefix: "Invoice", format: "PREFIX", separator: "-", digits: 5, initCounter: "daily", updateExistingRecord: false}
+let options = { field: 'serial', prefix: "Invoice", format: "PREFIX", separator: "-", digits: 5, initCounter: "daily", ignoreIncrementOnEdit: false}
 
 describe('Helper-functions', function () {
   it('should add lead zeros to integer number', () => {

--- a/src/test/withoutDate.test.ts
+++ b/src/test/withoutDate.test.ts
@@ -7,7 +7,7 @@ let connection: any;
 const should = require('chai').should()
 
 
-let options = { field: 'serial', prefix: "Invoice", separator: "-", digits: 5, updateExistingRecord: false}
+let options = { field: 'serial', prefix: "Invoice", separator: "-", digits: 5, ignoreIncrementOnEdit: false}
 
 before(function (done) {
   connection = mongoose.createConnection('mongodb://127.0.0.1/mongoose-serial-without-date', { useNewUrlParser: true, useUnifiedTopology: true });

--- a/src/test/withoutDate.test.ts
+++ b/src/test/withoutDate.test.ts
@@ -7,7 +7,7 @@ let connection: any;
 const should = require('chai').should()
 
 
-let options = { field: 'serial', prefix: "Invoice", separator: "-", digits: 5 }
+let options = { field: 'serial', prefix: "Invoice", separator: "-", digits: 5, updateExistingRecord: false}
 
 before(function (done) {
   connection = mongoose.createConnection('mongodb://127.0.0.1/mongoose-serial-without-date', { useNewUrlParser: true, useUnifiedTopology: true });

--- a/src/test/withoutPrefix.test.ts
+++ b/src/test/withoutPrefix.test.ts
@@ -6,7 +6,7 @@ let connection: any;
 const should = require('chai').should()
 
 
-let options = { field: 'serial', separator: "-", digits: 5, initCounter: "yearly", updateExistingRecord: false}
+let options = { field: 'serial', separator: "-", digits: 5, initCounter: "yearly", ignoreIncrementOnEdit: false}
 
 before(function (done) {
   connection = mongoose.createConnection('mongodb://127.0.0.1/mongoose-serial-wihtout-prefix', { useNewUrlParser: true, useUnifiedTopology: true });

--- a/src/test/withoutPrefix.test.ts
+++ b/src/test/withoutPrefix.test.ts
@@ -6,7 +6,7 @@ let connection: any;
 const should = require('chai').should()
 
 
-let options = { field: 'serial', separator: "-", digits: 5, initCounter: "yearly" }
+let options = { field: 'serial', separator: "-", digits: 5, initCounter: "yearly", updateExistingRecord: false}
 
 before(function (done) {
   connection = mongoose.createConnection('mongodb://127.0.0.1/mongoose-serial-wihtout-prefix', { useNewUrlParser: true, useUnifiedTopology: true });

--- a/src/test/withoutPrefixAndDate.test.ts
+++ b/src/test/withoutPrefixAndDate.test.ts
@@ -6,7 +6,7 @@ let connection: any;
 const should = require('chai').should()
 
 
-let options = { field: 'serial', separator: "-", digits: 13, updateExistingRecord: false}
+let options = { field: 'serial', separator: "-", digits: 13, ignoreIncrementOnEdit: false}
 
 before(function (done) {
   connection = mongoose.createConnection('mongodb://127.0.0.1/mongoose-serial-wihtout-prefix-and-date', { useNewUrlParser: true, useUnifiedTopology: true });

--- a/src/test/withoutPrefixAndDate.test.ts
+++ b/src/test/withoutPrefixAndDate.test.ts
@@ -6,7 +6,7 @@ let connection: any;
 const should = require('chai').should()
 
 
-let options = { field: 'serial', separator: "-", digits: 13 }
+let options = { field: 'serial', separator: "-", digits: 13, updateExistingRecord: false}
 
 before(function (done) {
   connection = mongoose.createConnection('mongodb://127.0.0.1/mongoose-serial-wihtout-prefix-and-date', { useNewUrlParser: true, useUnifiedTopology: true });


### PR DESCRIPTION
There could be a scenario where the end customer doesn't want to increment serial number over edit operation. If we are updating the existing record pre-hook will increment it. So lib should be configurable enough to support this feature. I have added it to my branch.
Take a look at it. If it seems okay then we can merge it or we can discuss it further.

I have implemented it as a feature and updated the relative test cases. 
Looking forward to hearing from you.
Regards
Mustaque