### PR TITLE
feat: add startFrom option to set initial counter value

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ await invoice2.save(); // serialNumber: "INV-2024-04-00001"
 | `separator` | `string` | `"-"` | Separator between parts |
 | `digits` | `number` | `10` | Number of digits for the counter (1-20) |
 | `initCounter` | `InitCounter` | `InitCounter.NEVER` | When to reset the counter |
+| `startFrom` | `number` | `1` | Starting counter value (also used when counter resets) |
 | `ignoreIncrementOnEdit` | `boolean` | `true` | Skip increment on document updates |
 | `getCurrentDate` | `() => Date` | `() => new Date()` | Custom date function (useful for testing) |
 
@@ -144,6 +145,32 @@ ticketSchema.plugin(mongooseSerial, {
 // Result: "TKT/2024/03/000001"
 ```
 
+### Custom Starting Counter
+
+```typescript
+// Start numbering from a specific value (e.g., continuing from a legacy system)
+invoiceSchema.plugin(mongooseSerial, {
+  field: 'serialNumber',
+  prefix: 'INV',
+  separator: '-',
+  digits: 5,
+  startFrom: 1000
+});
+// Result: "INV-01000", "INV-01001", "INV-01002"
+
+// Works with time-based resets too — counter resets back to startFrom
+invoiceSchema.plugin(mongooseSerial, {
+  field: 'serialNumber',
+  prefix: 'INV',
+  separator: '-',
+  digits: 5,
+  initCounter: InitCounter.YEARLY,
+  startFrom: 500
+});
+// 2024: "INV-2024-00500", "INV-2024-00501"
+// 2025: "INV-2025-00500", "INV-2025-00501"  ← resets to 500, not 1
+```
+
 ### Without Prefix or Date
 
 ```typescript
@@ -189,6 +216,7 @@ Common validation errors:
 - Field must be of type String
 - Digits must be between 1 and 20
 - Separator must be a single character
+- `startFrom` must be a non-negative integer
 
 ## Performance Considerations
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,8 @@ export interface SerialOptions {
   ignoreIncrementOnEdit?: boolean;
   /** Custom date function (useful for testing) */
   getCurrentDate?: () => Date;
+  /** Starting counter value (defaults to 1) */
+  startFrom?: number;
 }
 
 /**
@@ -45,7 +47,8 @@ const DEFAULT_OPTIONS: Required<SerialOptions> = {
   initCounter: InitCounter.NEVER,
   digits: 10,
   ignoreIncrementOnEdit: true,
-  getCurrentDate: () => new Date()
+  getCurrentDate: () => new Date(),
+  startFrom: 1
 };
 
 /**
@@ -66,27 +69,27 @@ export const addZeros = (counter: number, size: number): string => {
  * @returns Next counter value
  */
 export const extractCounter = (options: Required<SerialOptions>, serial: string | null): string => {
-  const { separator, initCounter, digits } = options;
-  
+  const { separator, initCounter, digits, startFrom } = options;
+
   if (!serial) {
-    return addZeros(1, digits);
+    return addZeros(startFrom, digits);
   }
 
   const chunks = serial.split(separator);
   const counter = chunks[chunks.length - 1];
-  
+
   // Check if we need to reset counter based on time period
   if (initCounter !== InitCounter.NEVER) {
     const currentDate = options.getCurrentDate();
     const shouldReset = checkCounterReset(chunks, initCounter, currentDate);
     if (shouldReset) {
-      return addZeros(1, digits);
+      return addZeros(startFrom, digits);
     }
   }
 
   const currentCounter = parseInt(counter, 10);
   if (isNaN(currentCounter)) {
-    return addZeros(1, digits);
+    return addZeros(startFrom, digits);
   }
 
   return addZeros(currentCounter + 1, digits);
@@ -171,6 +174,10 @@ const validateOptions = (options: SerialOptions): void => {
   
   if (options.separator && options.separator.length > 1) {
     throw new Error("Separator must be a single character");
+  }
+
+  if (options.startFrom !== undefined && (!Number.isInteger(options.startFrom) || options.startFrom < 0)) {
+    throw new Error("startFrom must be a non-negative integer");
   }
 };
 

--- a/src/test/helperFunctions.test.ts
+++ b/src/test/helperFunctions.test.ts
@@ -1,14 +1,15 @@
 import { expect } from "chai";
 import { addZeros, extractCounter, InitCounter } from '../index';
 
-const options = { 
-  field: 'serial', 
-  prefix: "Invoice", 
-  format: "PREFIX", 
-  separator: "-", 
-  digits: 5, 
-  initCounter: InitCounter.DAILY, 
-  ignoreIncrementOnEdit: false 
+const options = {
+  field: 'serial',
+  prefix: "Invoice",
+  format: "PREFIX",
+  separator: "-",
+  digits: 5,
+  initCounter: InitCounter.DAILY,
+  ignoreIncrementOnEdit: false,
+  startFrom: 1
 };
 
 describe('Helper-functions', function () {

--- a/src/test/integration.test.ts
+++ b/src/test/integration.test.ts
@@ -56,6 +56,14 @@ describe('Integration Tests - Plugin Functionality', () => {
     expect(() => {
       schema.plugin(plugin, { field: 'serialNumber', separator: '--' });
     }).to.throw('Separator must be a single character');
+
+    expect(() => {
+      schema.plugin(plugin, { field: 'serialNumber', startFrom: -1 });
+    }).to.throw('startFrom must be a non-negative integer');
+
+    expect(() => {
+      schema.plugin(plugin, { field: 'serialNumber', startFrom: 1.5 });
+    }).to.throw('startFrom must be a non-negative integer');
   });
 
   it('should work with different InitCounter values', () => {

--- a/src/test/unit.test.ts
+++ b/src/test/unit.test.ts
@@ -25,12 +25,19 @@ describe('Unit Tests - Core Functions', () => {
       initCounter: InitCounter.NEVER,
       digits: 5,
       ignoreIncrementOnEdit: true,
-      getCurrentDate: () => new Date('2024-03-15T10:00:00Z')
+      getCurrentDate: () => new Date('2024-03-15T10:00:00Z'),
+      startFrom: 1
     };
 
     it('should return 1 for null serial', () => {
       const result = extractCounter(baseOptions, null);
       expect(result).to.equal('00001');
+    });
+
+    it('should return startFrom for null serial', () => {
+      const options = { ...baseOptions, startFrom: 100 };
+      const result = extractCounter(options, null);
+      expect(result).to.equal('00100');
     });
 
     it('should increment counter for existing serial', () => {
@@ -62,16 +69,24 @@ describe('Unit Tests - Core Functions', () => {
       expect(result).to.equal('00001'); // Should reset for new hour
     });
 
+    it('should reset to startFrom on period rollover', () => {
+      const options = { ...baseOptions, initCounter: InitCounter.YEARLY, startFrom: 50 };
+      const result = extractCounter(options, 'TEST-2023-00050');
+      expect(result).to.equal('00050'); // resets to startFrom, not 1
+    });
+
+    it('should handle invalid counter gracefully using startFrom', () => {
+      const options = { ...baseOptions, startFrom: 10 };
+      const result = extractCounter(options, 'TEST-INVALID');
+      expect(result).to.equal('00010');
+    });
+
     it('should not reset for same time period', () => {
       const options = { ...baseOptions, initCounter: InitCounter.MONTHLY };
       const result = extractCounter(options, 'TEST-2024-03-00001');
       expect(result).to.equal('00002'); // Should increment, not reset
     });
 
-    it('should handle invalid counter gracefully', () => {
-      const result = extractCounter(baseOptions, 'TEST-INVALID');
-      expect(result).to.equal('00001');
-    });
   });
 
   describe('InitCounter enum', () => {

--- a/src/test/withStartFrom.test.ts
+++ b/src/test/withStartFrom.test.ts
@@ -1,0 +1,89 @@
+import { expect } from "chai";
+import { plugin, InitCounter } from '../index';
+
+const mongoose = require('mongoose');
+let connection: any;
+
+before(async function () {
+  connection = mongoose.createConnection('mongodb://127.0.0.1/mongoose-serial-start-from');
+  await connection.asPromise();
+});
+
+after(async function () {
+  await connection.db.dropDatabase();
+  await connection.close();
+});
+
+describe('Mongoose-serial with startFrom', function () {
+
+  it('should start counter at startFrom value', async function () {
+    const schema = new mongoose.Schema({ serial: String, amount: Number });
+    schema.plugin(plugin, {
+      field: 'serial',
+      prefix: 'INV',
+      separator: '-',
+      digits: 5,
+      startFrom: 100,
+    });
+    const Invoice = connection.model('InvoiceStartFrom', schema);
+
+    const doc1 = await new Invoice({ amount: 1000 }).save();
+    const doc2 = await new Invoice({ amount: 2000 }).save();
+    const doc3 = await new Invoice({ amount: 3000 }).save();
+
+    expect(doc1.serial).to.match(/-00100$/);
+    expect(doc2.serial).to.match(/-00101$/);
+    expect(doc3.serial).to.match(/-00102$/);
+  });
+
+  it('should reset to startFrom on period rollover', async function () {
+    const schema = new mongoose.Schema({ serial: String, amount: Number });
+    const pastDate = new Date('2023-01-15T10:00:00Z');
+    const futureDate = new Date('2025-06-01T10:00:00Z');
+
+    schema.plugin(plugin, {
+      field: 'serial',
+      separator: '-',
+      digits: 5,
+      initCounter: InitCounter.YEARLY,
+      startFrom: 50,
+      getCurrentDate: () => pastDate,
+    });
+    const Invoice = connection.model('InvoiceReset', schema);
+
+    // Save one in the "past"
+    await new Invoice({ amount: 1000 }).save();
+
+    // Now simulate a year rollover by updating the date function on the options
+    // We create a second model with a different date to verify reset behavior via extractCounter directly
+    const { extractCounter } = require('../index');
+    const opts = {
+      field: 'serial',
+      prefix: '',
+      format: '',
+      separator: '-',
+      digits: 5,
+      initCounter: InitCounter.YEARLY,
+      startFrom: 50,
+      ignoreIncrementOnEdit: true,
+      getCurrentDate: () => futureDate,
+    };
+
+    // A serial from a different year should reset to startFrom
+    const next = extractCounter(opts, '2023-00050');
+    expect(next).to.equal('00050');
+  });
+
+  it('should default startFrom to 1 when not provided', async function () {
+    const schema = new mongoose.Schema({ serial: String, amount: Number });
+    schema.plugin(plugin, {
+      field: 'serial',
+      separator: '-',
+      digits: 5,
+    });
+    const Invoice = connection.model('InvoiceDefault', schema);
+
+    const doc = await new Invoice({ amount: 500 }).save();
+    expect(doc.serial).to.equal('00001');
+  });
+});


### PR DESCRIPTION
#  Description
Implements the startFrom option requested in issue #25. The counter now starts at startFrom (defaults to 1) for the first document and resets to startFrom on date period rollovers — not always 1.Fixes the original PR #26 issues: missing default, inconsistent reset behavior on rollovers, and tests that never asserted the actual serial value. Also adds validation that startFrom is a non-negative integer.